### PR TITLE
Add possiblity to skip jwt verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ _testmain.go
 # IntelliJ
 .idea/
 
+# VSCode
+.vscode
+
 # Emacs
 *~
 \#*\#
@@ -48,3 +51,4 @@ coverage.out
 
 # Cross compiled binaries
 pkg
+


### PR DESCRIPTION
This PR adds the possibility to bypass JWT verification.

## Why
In our company, we're trying to integrate NATS with a multi-tenancy keycloak setup.
Having many different keycloak realms, clients from different realms will connect to NATS -- where each realm has its own jwt public signing key.
As we are verifying the JWT in our gateway, it is not necessary to do the verification again.
By skipping the verification, your fork seems to be a perfect fit for our use case. 

## Usage
`JWT_SKIP_VALIDATION=true nats-server`

When setting the `JWT_SKIP_VALIDTION` env variable to `true`, `JWT_SIGNER_PUBLIC_KEY`  can be omitted.

